### PR TITLE
print대신 logging 사용.

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,5 +1,8 @@
 import discord
 from discord.ext import commands
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 TOKEN = 'token'
 
@@ -9,8 +12,7 @@ class qabot(commands.Bot):
         self.load_extension('qa')
 
     async def on_ready(self):
-        print(self.user.name, 'Ready!')
-        print('\n')
+        logging.info(f'{self.user.name} Ready!\n')
 
     async def on_message(self, msg):
         await self.process_commands(msg)


### PR DESCRIPTION
logging모듈을 가져와서 INFO로 설정하고 난 후
봇의 준비 상태를 기록하기 위해 print를 logging.info로 대체했습니다.